### PR TITLE
Fixed: Unsigned Integer now writes correctly 

### DIFF
--- a/src/Field/Float.php
+++ b/src/Field/Float.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * php-binary
+ * A PHP library for parsing structured binary streams
+ *
+ * @package  php-binary
+ * @author Damien Walsh <me@damow.net>
+ */
+namespace Binary\Field;
+
+use Binary\DataSet;
+use Binary\Stream\StreamInterface;
+
+/**
+ * Float
+ * Field.
+ *
+ * @since 1.0
+ */
+class Float extends AbstractSizedField
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function read(StreamInterface $stream, DataSet $result)
+    {
+        $data = $stream->read($this->size->get($result));
+
+        if (strlen($data) < 2) {
+            $data = str_pad($data, 2, "\0", STR_PAD_LEFT);
+        }
+
+        $unpacked = unpack('f', $data);
+        $this->validate($unpacked[1]);
+        $result->setValue($this->name, $unpacked[1]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write(StreamInterface $stream, DataSet $result)
+    {
+        //Writing floats currently untested
+        $bytes = $result->getValue($this->name);
+        $stream->write(pack('f', intval($bytes)));
+    }
+}

--- a/src/Field/UnsignedInteger.php
+++ b/src/Field/UnsignedInteger.php
@@ -40,7 +40,14 @@ class UnsignedInteger extends AbstractSizedField
      */
     public function write(StreamInterface $stream, DataSet $result)
     {
-        $bytes = $result->getValue($this->getName());
-        $stream->write(pack('c', intval($bytes)));
+        $dataSize = $this->size->get($result);
+
+        $bytes = $result->getValue($this->name);
+
+        for($i = 0; $i < $dataSize; $i++ ){
+            $unsignedByte = (($bytes >> (($dataSize - (1+ $i)) * 8)) & 0xFF); //big endian
+            $stream->write(pack('C', intval($unsignedByte) & 0xFF));
+            //$bytes = $bytes >> 8; //little Endian
+        }
     }
 }


### PR DESCRIPTION
Fixed: Unsigned Integer now outputs correctly when larger than 1 byte - Big Endian only for now
Added: Float Type
